### PR TITLE
Adds parentheses to awk functions.

### DIFF
--- a/namesilo_ddns.sh
+++ b/namesilo_ddns.sh
@@ -26,7 +26,7 @@ get_random()
 	max=$1
 	add=${2-0}
 
-	expr $(echo | awk "{srand; print int(rand * $max)}") + $add
+	expr $(echo | awk "{srand(); print int(rand() * $max)}") + $add
 }
 
 get_ip()


### PR DESCRIPTION
For compatibility with Ubuntu. Otherwise it produces a syntax error.