### PR TITLE
Disables file globbing.

### DIFF
--- a/namesilo_ddns.sh
+++ b/namesilo_ddns.sh
@@ -19,6 +19,7 @@ else
     exit 1
 fi
 
+set -f
 set -- $HOSTS
 
 get_random()


### PR DESCRIPTION
This allows the wildcard A record (*) to be updated if listed as one of the hosts in the .conf file.